### PR TITLE
[FEAT] API Response format 지정

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@nestjs/platform-express": "^8.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.5.5"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,11 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return data "Hello World!"', () => {
+      expect(appController.getHello()).toStrictEqual({
+        message: 'Get Hello 성공',
+        data: 'Hello World!',
+      });
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from './types/global';
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
 
@@ -6,7 +7,7 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
+  getHello(): ApiResponse<string> {
     return this.appService.getHello();
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,15 @@
+import { ResponseInterceptor } from './response.interceptor';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    { provide: APP_INTERCEPTOR, useClass: ResponseInterceptor },
+  ],
 })
 export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { ApiResponse } from './types/global';
 
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+  getHello(): ApiResponse<string> {
+    return {
+      message: 'Get Hello 성공',
+      data: 'Hello World!',
+    };
   }
 }

--- a/src/response.interceptor.ts
+++ b/src/response.interceptor.ts
@@ -1,0 +1,28 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface Response<S, T> {
+  message: S;
+  data: T;
+}
+
+@Injectable()
+export class ResponseInterceptor<S, T>
+  implements NestInterceptor<T, Response<S, T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<Response<S, T>> {
+    const status = context.switchToHttp().getResponse().statusCode;
+    return next
+      .handle()
+      .pipe(map(({ message, data }) => ({ status, message, data })));
+  }
+}

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,0 +1,4 @@
+export interface ApiResponse<T> {
+  message: string;
+  data: T;
+}


### PR DESCRIPTION
## Issue Ticket 🎫
- Close #2 

## Describe your changes 🧾
- API 응답 형태를 고정하기 위해서 response interceptor 를 추가
- Interceptor 에서 status code 를 자동으로 응답에 붙여준다.
- 또한 global type 으로 `ApiResponse` 를 선언해서, 모든 Api 의 응답이 message 를 포함하도록 한다.
```typescript
export interface ApiResponse<T> {
  message: string;
  data: T;
}
```
```typescript
getHello(): ApiResponse<string> {
    return {
      message: 'Get Hello 성공',
      data: 'Hello World!',
    };
  }
```

