### PR TITLE
[FEAT] 모든 entity 및 resource 정의

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^8.0.0",
         "@nestjs/config": "^2.0.0",
         "@nestjs/core": "^8.0.0",
+        "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^8.0.0",
         "@nestjs/typeorm": "^8.0.3",
         "pg": "^8.7.3",
@@ -1421,6 +1422,25 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+      "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -10178,7 +10198,8 @@
     "@nestjs/mapped-types": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
-      "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg=="
+      "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+      "requires": {}
     },
     "@nestjs/platform-express": {
       "version": "8.4.4",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { FeedModule } from './feed/feed.module';
 import { ResponseInterceptor } from './response.interceptor';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -5,7 +6,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
@@ -27,6 +28,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
         synchronize: true,
       }),
     }),
+    UserModule,
+    FeedModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/book/entities/book.entity.ts
+++ b/src/book/entities/book.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Book {
+  @PrimaryColumn()
+  isbn: number;
+
+  @Column()
+  sub_isbn: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  author: string;
+
+  @Column()
+  image: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column({ default: false })
+  is_deleted: boolean;
+}

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -1,0 +1,1 @@
+export class CreateFeedDto {}

--- a/src/feed/dto/update-feed.dto.ts
+++ b/src/feed/dto/update-feed.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateFeedDto } from './create-feed.dto';
+
+export class UpdateFeedDto extends PartialType(CreateFeedDto) {}

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -1,0 +1,46 @@
+import { User } from './../../user/entities/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Book } from '../../book/entities/book.entity';
+
+@Entity()
+export class Feed {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  category_name: string;
+
+  @ManyToOne(() => Book, (book) => book.isbn)
+  @JoinColumn({ name: 'isbn' })
+  isbn: number;
+
+  @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user_id: number;
+
+  @Column()
+  sentence: string;
+
+  @Column()
+  feeling: string;
+
+  @Column()
+  reported_count: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column({ default: false })
+  is_deleted: boolean;
+}

--- a/src/feed/feed.controller.spec.ts
+++ b/src/feed/feed.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeedController } from './feed.controller';
+import { FeedService } from './feed.service';
+
+describe('FeedController', () => {
+  let controller: FeedController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeedController],
+      providers: [FeedService],
+    }).compile();
+
+    controller = module.get<FeedController>(FeedController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { FeedService } from './feed.service';
+import { CreateFeedDto } from './dto/create-feed.dto';
+import { UpdateFeedDto } from './dto/update-feed.dto';
+
+@Controller('feed')
+export class FeedController {
+  constructor(private readonly feedService: FeedService) {}
+
+  @Post()
+  create(@Body() createFeedDto: CreateFeedDto) {
+    return this.feedService.create(createFeedDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.feedService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.feedService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateFeedDto: UpdateFeedDto) {
+    return this.feedService.update(+id, updateFeedDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.feedService.remove(+id);
+  }
+}

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FeedService } from './feed.service';
+import { FeedController } from './feed.controller';
+
+@Module({
+  controllers: [FeedController],
+  providers: [FeedService],
+})
+export class FeedModule {}

--- a/src/feed/feed.service.spec.ts
+++ b/src/feed/feed.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeedService } from './feed.service';
+
+describe('FeedService', () => {
+  let service: FeedService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FeedService],
+    }).compile();
+
+    service = module.get<FeedService>(FeedService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateFeedDto } from './dto/create-feed.dto';
+import { UpdateFeedDto } from './dto/update-feed.dto';
+
+@Injectable()
+export class FeedService {
+  create(createFeedDto: CreateFeedDto) {
+    return 'This action adds a new feed';
+  }
+
+  findAll() {
+    return `This action returns all feed`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} feed`;
+  }
+
+  update(id: number, updateFeedDto: UpdateFeedDto) {
+    return `This action updates a #${id} feed`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} feed`;
+  }
+}

--- a/src/report/entities/report.entity.ts
+++ b/src/report/entities/report.entity.ts
@@ -1,0 +1,41 @@
+import { User } from './../../user/entities/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Feed } from '../../feed/entities/feed.entity';
+
+@Entity()
+export class Report {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'report_user_id' })
+  report_user_id: number;
+
+  @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'reported_user_id' })
+  reported_user_id: number;
+
+  @ManyToOne(() => Feed, (feed) => feed.id)
+  @JoinColumn({ name: 'reported_feed_id' })
+  reported_feed_id: number;
+
+  @Column()
+  reason: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column({ default: false })
+  is_deleted: boolean;
+}

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,0 +1,1 @@
+export class CreateUserDto {}

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Feed } from '../../feed/entities/feed.entity';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  uid: string;
+
+  @Column()
+  nickname: string;
+
+  @Column()
+  refresh_token: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column({ default: false })
+  is_deleted: boolean;
+
+  @OneToMany(() => Feed, (feed) => feed.user_id)
+  feeds: Feed[];
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [UserService],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { UserService } from './user.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+@Controller('user')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Post()
+  create(@Body() createUserDto: CreateUserDto) {
+    return this.userService.create(createUserDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.userService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.userService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+    return this.userService.update(+id, updateUserDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.userService.remove(+id);
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+import { UserController } from './user.controller';
+
+@Module({
+  controllers: [UserController],
+  providers: [UserService],
+})
+export class UserModule {}

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+@Injectable()
+export class UserService {
+  create(createUserDto: CreateUserDto) {
+    return 'This action adds a new user';
+  }
+
+  findAll() {
+    return `This action returns all user`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} user`;
+  }
+
+  update(id: number, updateUserDto: UpdateUserDto) {
+    return `This action updates a #${id} user`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} user`;
+  }
+}


### PR DESCRIPTION
## Issue Ticket 🎫
- Close #9 

## Describe your changes 🧾
- package-lock.json update
- ERD 에 대응해서 모든 entity 정의 완료
- Feed와 User (auth) 는 API 만들어야 하니까 resource 까지 만들어 뒀습니다. ( 각자 파트 하는 사람이 구현만 하면 되도록 )
- 그래서 당장 service, controller, module, dto 파트는 볼 필요 없습니다. Entity 정의만 봐주세요 :) 

완성된 diagram
![image](https://user-images.githubusercontent.com/44252639/167850431-de90bdcb-1982-4254-838b-0925a6098e88.png)

