### PR TITLE
[FEAT] HttpExceptionFilter 도입 및 ApiResponse generic optional

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { FeedModule } from './feed/feed.module';
 import { ResponseInterceptor } from './response.interceptor';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { UserModule } from './user/user.module';
+import { HttpExceptionFilter } from './http-exception.filter';
 
 @Module({
   imports: [
@@ -30,6 +31,12 @@ import { UserModule } from './user/user.module';
     FeedModule,
   ],
   controllers: [],
-  providers: [{ provide: APP_INTERCEPTOR, useClass: ResponseInterceptor }],
+  providers: [
+    { provide: APP_INTERCEPTOR, useClass: ResponseInterceptor },
+    {
+      provide: APP_FILTER,
+      useClass: HttpExceptionFilter,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/http-exception.filter.ts
+++ b/src/http-exception.filter.ts
@@ -1,0 +1,27 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+    const { message, data } = exception.getResponse() as {
+      message: string;
+      data: object;
+    };
+
+    response.status(status).json({
+      status,
+      success: false,
+      message,
+      data,
+    });
+  }
+}

--- a/src/response.interceptor.ts
+++ b/src/response.interceptor.ts
@@ -23,6 +23,8 @@ export class ResponseInterceptor<S, T>
     const status = context.switchToHttp().getResponse().statusCode;
     return next
       .handle()
-      .pipe(map(({ message, data }) => ({ status, message, data })));
+      .pipe(
+        map(({ message, data }) => ({ status, success: true, message, data })),
+      );
   }
 }

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,4 +1,4 @@
-export interface ApiResponse<T> {
+export interface ApiResponse<T = void> {
   message: string;
-  data: T;
+  data?: T;
 }


### PR DESCRIPTION
## Issue Ticket 🎫
- Close #20 

## Describe your changes 🧾
- HttpExceptionFilter 추가해서 exception 발생 시 응답 핸들링
- 응답에 data 가 필요없는 API 의 경우 ApiResponse 만 리턴하도록 수정.
- 이를 적용한 예시 ( 피드 삭제 API )
```typescript
  async remove(feedId: string): Promise<ApiResponse> {
    if (!+feedId) {
      throw new HttpException(
        {
          message: '피드 삭제 실패. feedId 값을 확인하세요.',
          data: feedId,
        },
        HttpStatus.BAD_REQUEST,
      );
    }
    const feed = await this.feedsRepository.findOneBy({ id: +feedId });
    if (!feed) {
      throw new HttpException(
        {
          message: '피드 삭제 실패. 피드가 없습니다.',
        },
        HttpStatus.NOT_FOUND,
      );
    }
    await this.feedsRepository.save({
      ...feed,
      is_deleted: true,
    });
    return {
      message: '피드 삭제 성공',
    };
  }
}
```


