### PR TITLE
[FIX] 피드 생성 API 수정 및 Guards 설정 추가

### DIFF
--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsObject, IsString } from 'class-validator';
-import { User } from '../../user/entities/user.entity';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class CreateFeedDto {
+  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '카테고리 이름',
@@ -10,6 +10,7 @@ export class CreateFeedDto {
   })
   categoryName: string;
 
+  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '인상 깊은 문장',
@@ -18,6 +19,7 @@ export class CreateFeedDto {
   })
   sentence: string;
 
+  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '느낀점',
@@ -26,6 +28,7 @@ export class CreateFeedDto {
   })
   feeling: string;
 
+  @IsNotEmpty()
   @IsNumber()
   @ApiProperty({
     description: '도서 고유 번호',
@@ -33,6 +36,7 @@ export class CreateFeedDto {
   })
   isbn: number;
 
+  @IsNotEmpty()
   @IsNumber()
   @ApiProperty({
     description: '서브 도서 고유 번호',
@@ -40,6 +44,7 @@ export class CreateFeedDto {
   })
   subIsbn: number;
 
+  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '도서 제목',
@@ -47,6 +52,7 @@ export class CreateFeedDto {
   })
   title: string;
 
+  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '저자',
@@ -54,25 +60,11 @@ export class CreateFeedDto {
   })
   author: string;
 
+  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '썸네일 이미지 url',
     default: 'image',
   })
   image: string;
-
-  @IsObject()
-  @ApiProperty({
-    description: '사용자 정보',
-    default: {
-      id: 1,
-      uid: 'kakao@1234',
-      nickname: '갓영권',
-      refreshToken: 'temporary_token',
-      createdAt: '2022-05-12T22:12:35.253Z',
-      updatedAt: '2022-05-14T01:11:45.480Z',
-      isDeleted: false,
-    },
-  })
-  user: User;
 }

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -7,20 +7,24 @@ import {
   Param,
   Delete,
   Query,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
 import { FeedService } from './feed.service';
 import { CreateFeedDto } from './dto/create-feed.dto';
 import { UpdateFeedDto } from './dto/update-feed.dto';
-import { ApiHeader, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller('feed')
 @ApiTags('feed')
 export class FeedController {
   constructor(private readonly feedService: FeedService) {}
 
   @Post()
-  create(@Body() createFeedDto: CreateFeedDto) {
-    return this.feedService.create(createFeedDto);
+  create(@Req() req, @Body() createFeedDto: CreateFeedDto) {
+    return this.feedService.create(req.user, createFeedDto);
   }
 
   @Get()

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -5,9 +5,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Feed } from './entities/feed.entity';
 import { Book } from '../book/entities/book.entity';
 import { User } from '../user/entities/user.entity';
+import { AuthModule } from 'src/auth/auth.module';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Feed, Book, User])],
+  imports: [
+    TypeOrmModule.forFeature([Feed, Book, User]),
+    AuthModule,
+    UserModule,
+  ],
   controllers: [FeedController],
   providers: [FeedService],
 })

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -19,16 +19,28 @@ export class FeedService {
     private usersRepository: Repository<User>,
   ) {}
   async create(
+    user: User,
     createFeedDto: CreateFeedDto,
-  ): Promise<ApiResponse<{ id: number; createdAt: Date; updatedAt: Date }>> {
+  ): Promise<ApiResponse<{ id: number; createdAt: Date }>> {
     try {
       await this.booksRepository.save(createFeedDto);
-      const { id, createdAt, updatedAt } = await this.feedsRepository.save(
-        createFeedDto,
-      );
+
+      const { categoryName, sentence, feeling, isbn, title } = createFeedDto;
+
+      const feed = {
+        categoryName,
+        sentence,
+        feeling,
+        isbn,
+        user,
+        title,
+      };
+
+      const { id, createdAt } = await this.feedsRepository.save(feed);
+
       return {
         message: '피드 추가 성공',
-        data: { id, createdAt, updatedAt },
+        data: { id, createdAt },
       };
     } catch (e) {
       console.error(e);

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -16,5 +16,6 @@ import { AuthModule } from 'src/auth/auth.module';
   ],
   controllers: [UserController],
   providers: [UserService, AuthService],
+  exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #42 

<br>




## Describe your changes 🧾


- create-feed.dto에서 User 필드 삭제
- 피드 작성 시 토큰을 파싱해서 얻은 유저 정보로 저장하도록 수정 
- feed.controller.ts에 컨트롤러 범위 UserGuards 적용
- ```피드 생성 response```에서 ```updatedAt``` 제거

<br>


