### PR TITLE
[FIX] ```isbn```, ```sub_isbn``` 타입 string으로 변경 & ```POST /feed```에서 image 필드에 빈 스트링 넣을 수 있게 수정

### DIFF
--- a/src/book/entities/book.entity.ts
+++ b/src/book/entities/book.entity.ts
@@ -11,11 +11,11 @@ import {
 export class Book {
   @PrimaryColumn()
   @Exclude()
-  isbn: number;
+  isbn: string;
 
-  @Column({ nullable: true })
+  @Column()
   @Exclude()
-  subIsbn: number;
+  subIsbn: string;
 
   @Column()
   @Exclude()

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -60,7 +60,6 @@ export class CreateFeedDto {
   })
   author: string;
 
-  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '썸네일 이미지 url',

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -29,20 +29,20 @@ export class CreateFeedDto {
   feeling: string;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   @ApiProperty({
     description: '도서 고유 번호',
-    default: 1234,
+    default: '1234',
   })
-  isbn: number;
+  isbn: string;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   @ApiProperty({
     description: '서브 도서 고유 번호',
-    default: 56789,
+    default: '56789',
   })
-  subIsbn: number;
+  subIsbn: string;
 
   @IsNotEmpty()
   @IsString()

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -23,7 +23,7 @@ export class Feed {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'isbn' })
-  isbn: number;
+  isbn: string;
 
   @Column()
   title: string;

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -25,7 +25,7 @@ export class Feed {
   @JoinColumn({ name: 'isbn' })
   isbn: number;
 
-  @Column({ nullable: true })
+  @Column()
   title: string;
 
   @ManyToOne(() => User, (user) => user.id, {


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #50 

<br>




## Describe your changes 🧾


- 모든 entity에서 isbn, sub_isbn 타입 string으로 변경.
- _feed.entity.ts_ - title 컬럼 { nullable: true } 옵션 제거
- _create-feed.dto_ - image 필드 IsNotEmpty() 옵션 제거
- synchronize 문제로 DB에서 ```feed```, ```book``` 테이블 삭제하고 다시 만듦.
- ```feed```, ```book``` 테이블에 더미 데이터 추가.

해당 pr은 리뷰 끝나는 대로 빠르게 머지하고 배포합시다~
<br>


