### PR TITLE
[FIX] Swagger ```GET /feed```에서 필터 선택 안 할 수 있도록 수정

### DIFF
--- a/src/book/entities/book.entity.ts
+++ b/src/book/entities/book.entity.ts
@@ -11,11 +11,11 @@ import {
 export class Book {
   @PrimaryColumn()
   @Exclude()
-  isbn: number;
+  isbn: string;
 
-  @Column({ nullable: true })
+  @Column()
   @Exclude()
-  subIsbn: number;
+  subIsbn: string;
 
   @Column()
   @Exclude()

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -60,7 +60,6 @@ export class CreateFeedDto {
   })
   author: string;
 
-  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '썸네일 이미지 url',

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -29,20 +29,20 @@ export class CreateFeedDto {
   feeling: string;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   @ApiProperty({
     description: '도서 고유 번호',
-    default: 1234,
+    default: '1234',
   })
-  isbn: number;
+  isbn: string;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   @ApiProperty({
     description: '서브 도서 고유 번호',
-    default: 56789,
+    default: '56789',
   })
-  subIsbn: number;
+  subIsbn: string;
 
   @IsNotEmpty()
   @IsString()

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -23,7 +23,7 @@ export class Feed {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'isbn' })
-  isbn: number;
+  isbn: string;
 
   @Column()
   title: string;

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -25,7 +25,7 @@ export class Feed {
   @JoinColumn({ name: 'isbn' })
   isbn: number;
 
-  @Column({ nullable: true })
+  @Column()
   title: string;
 
   @ManyToOne(() => User, (user) => user.id, {

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -29,7 +29,7 @@ export class FeedController {
   }
 
   @Get()
-  @ApiQuery({ name: 'filters', description: '분류 카테고리' })
+  @ApiQuery({ name: 'filters', description: '분류 카테고리', required: false })
   findAll(@Query('filters') filters: string) {
     return this.feedService.findAll(filters);
   }

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -51,15 +51,16 @@ export class FeedService {
   async findAll(
     filters: string,
   ): Promise<ApiResponse<{ filters: string[]; feeds: Feed[] }>> {
-    const filterArr = filters.split(',');
-
+    let filterArr: string[];
     let feeds: Feed[];
 
     if (!filters) {
+      filterArr = [''];
       feeds = await this.feedsRepository.find({
         where: { isDeleted: false },
       });
     } else {
+      filterArr = filters.split(',');
       feeds = await this.feedsRepository.find({
         where: { isDeleted: false, categoryName: In(filterArr) },
       });


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #52 

#51 pr이 머지 되었다는 가정 하에 작성함.

<br>




## Describe your changes 🧾


- before
<img width="233" alt="스크린샷 2022-06-17 오전 7 50 56" src="https://user-images.githubusercontent.com/70746467/174191046-c990df43-2a08-403f-9f0c-c7c0a766a8ea.png">

- after
<img width="242" alt="스크린샷 2022-06-17 오전 7 51 49" src="https://user-images.githubusercontent.com/70746467/174191135-cc2c05e6-396d-4e1f-9d75-3c1c80a9665a.png">

- 필터 선택 안 한 경우 __filters__ 반환 값
<img width="264" alt="스크린샷 2022-06-17 오전 7 52 44" src="https://user-images.githubusercontent.com/70746467/174191240-dacc7ccc-42ed-4a70-ae56-7f200cbce7e8.png">

✅  노션 명세서 수정 완료
<br>


