### PR TITLE
[FIX] 전체 피드 목록 조회 시 createdAt 기준으로 정렬하여 반환하도록 수정

### DIFF
--- a/src/book/entities/book.entity.ts
+++ b/src/book/entities/book.entity.ts
@@ -11,11 +11,11 @@ import {
 export class Book {
   @PrimaryColumn()
   @Exclude()
-  isbn: number;
+  isbn: string;
 
-  @Column({ nullable: true })
+  @Column()
   @Exclude()
-  subIsbn: number;
+  subIsbn: string;
 
   @Column()
   @Exclude()

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -60,7 +60,6 @@ export class CreateFeedDto {
   })
   author: string;
 
-  @IsNotEmpty()
   @IsString()
   @ApiProperty({
     description: '썸네일 이미지 url',

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -29,20 +29,20 @@ export class CreateFeedDto {
   feeling: string;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   @ApiProperty({
     description: '도서 고유 번호',
-    default: 1234,
+    default: '1234',
   })
-  isbn: number;
+  isbn: string;
 
   @IsNotEmpty()
-  @IsNumber()
+  @IsString()
   @ApiProperty({
     description: '서브 도서 고유 번호',
-    default: 56789,
+    default: '56789',
   })
-  subIsbn: number;
+  subIsbn: string;
 
   @IsNotEmpty()
   @IsString()

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -23,7 +23,7 @@ export class Feed {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'isbn' })
-  isbn: number;
+  isbn: string;
 
   @Column()
   title: string;

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -25,7 +25,7 @@ export class Feed {
   @JoinColumn({ name: 'isbn' })
   isbn: number;
 
-  @Column({ nullable: true })
+  @Column()
   title: string;
 
   @ManyToOne(() => User, (user) => user.id, {

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -29,7 +29,7 @@ export class FeedController {
   }
 
   @Get()
-  @ApiQuery({ name: 'filters', description: '분류 카테고리' })
+  @ApiQuery({ name: 'filters', description: '분류 카테고리', required: false })
   findAll(@Query('filters') filters: string) {
     return this.feedService.findAll(filters);
   }

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -51,15 +51,16 @@ export class FeedService {
   async findAll(
     filters: string,
   ): Promise<ApiResponse<{ filters: string[]; feeds: Feed[] }>> {
-    const filterArr = filters.split(',');
-
+    let filterArr: string[];
     let feeds: Feed[];
 
     if (!filters) {
+      filterArr = [''];
       feeds = await this.feedsRepository.find({
         where: { isDeleted: false },
       });
     } else {
+      filterArr = filters.split(',');
       feeds = await this.feedsRepository.find({
         where: { isDeleted: false, categoryName: In(filterArr) },
       });

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -58,11 +58,13 @@ export class FeedService {
       filterArr = [''];
       feeds = await this.feedsRepository.find({
         where: { isDeleted: false },
+        order: { createdAt: 'DESC' },
       });
     } else {
       filterArr = filters.split(',');
       feeds = await this.feedsRepository.find({
         where: { isDeleted: false, categoryName: In(filterArr) },
+        order: { createdAt: 'DESC' },
       });
     }
     return {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -187,6 +187,7 @@ export class UserService {
     }
     const feeds = await this.feedsRepository.find({
       where: { user: { id: user.id }, isDeleted: false },
+      order: { createdAt: 'DESC' },
     });
     return {
       message: responseMessage.READ_ALL_FEEDS_SUCCESS,


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #54 

#51 #53 pr이 머지 되었다는 가정 하에 작성함.
<br>




## Describe your changes 🧾


- 전체 피드 목록 조회 API ```GET /feed``` 수정
- (마이페이지) 전체 피드 목록 조회 API ```GET /user/myFeeds``` 수정

<br>


