### PR TITLE
Feed 조회 시 Isbn 반환 오류 수정 시도

### DIFF
--- a/src/book/entities/book.entity.ts
+++ b/src/book/entities/book.entity.ts
@@ -5,7 +5,9 @@ import {
   Entity,
   PrimaryColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
+import { Feed } from '../../feed/entities/feed.entity';
 
 @Entity()
 export class Book {
@@ -38,4 +40,7 @@ export class Book {
   @Column({ default: false })
   @Exclude()
   isDeleted: boolean;
+
+  @OneToMany(() => Feed, (feed) => feed.book)
+  feeds: Feed[];
 }

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -23,7 +23,7 @@ export class Feed {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'isbn' })
-  isbn: string;
+  book: Book;
 
   @Column()
   title: string;

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -76,7 +76,7 @@ export class FeedService {
     };
   }
 
-  async findOne(feedId: string) {
+  async findOne(feedId: string): Promise<ApiResponse<{ feed: Feed }>> {
     if (!+feedId) {
       throw new HttpException(
         {
@@ -95,24 +95,23 @@ export class FeedService {
         HttpStatus.NOT_FOUND,
       );
     }
+    // console.log(feed) 하면 feed.isbn이 출력되지 않음
 
-    const book = await this.booksRepository.findOneBy({ isbn: feed.isbn });
-    if (!book || book.isDeleted) {
-      throw new HttpException(
-        {
-          message: responseMessage.NO_BOOK,
-        },
-        HttpStatus.NOT_FOUND,
-      );
-    }
-    const { author, image } = book;
+    // const book = await this.booksRepository.findOneBy({ isbn: feed.isbn });
+    // if (!book || book.isDeleted) {
+    //   throw new HttpException(
+    //     {
+    //       message: responseMessage.NO_BOOK,
+    //     },
+    //     HttpStatus.NOT_FOUND,
+    //   );
+    // }
 
     return {
       message: responseMessage.READ_ONE_FEED_SUCCESS,
       data: {
-        ...feed,
-        author,
-        image,
+        feed: feed,
+        // book: book,
       },
     };
   }


### PR DESCRIPTION
## Issue Ticket 🎫
#57 
- Feed Isbn 반환 오류 수정 시도

<br>




## Describe your changes 🧾


- 현재 피드 상세 조회, 피드 목록 조회 등 피드 조회 API들에서 같은 문제가 발생하고 있습니다.
- FeedService에서 feedRepository를 대상으로 한 find 함수 실행 시 반환되는 데이터에 feed의 isbn이 누락되어 있습니다. feed.isbn을 찍어보면 undefined로 나타납니다.
- 밑에 bookRepository에 feed.isbn으로 find해서 book의 author와 image를 가져오는데, 현재 feed.isbn이 undefined이므로 이상한 값이 읽히는 것으로 보입니다.
- Datagrip으로 DB ERD 확인했는데, feed 테이블에 isbn이 integer type으로 지정되어 있어 varchar로 변경하였습니다.
- 이를 위해 우선 findOne 함수에 Promise 타입 지정이 빠져 있어 이를 먼저 해 주었습니다.
- Book Entity에 OneToMany Decoration이 누락되어 추가했습니다.
- Feed Entity에 JoinColumn 옵션을 수정했습니다.
- Book Entity에 Exclude Decoration을 지워보아도 문제가 해결되지 않았습니다.

<br>


