### PR TITLE
[FIX] book, feed 엔티티 사이 relation 정의 및 피드 관련 로직 수정

### DIFF
--- a/src/book/dto/create-book.dto.ts
+++ b/src/book/dto/create-book.dto.ts
@@ -1,0 +1,23 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateBookDto {
+  @IsNotEmpty()
+  @IsString()
+  isbn: string;
+
+  @IsNotEmpty()
+  @IsString()
+  subIsbn: string;
+
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  author: string;
+
+  @IsNotEmpty()
+  @IsString()
+  image: string;
+}

--- a/src/book/entities/book.entity.ts
+++ b/src/book/entities/book.entity.ts
@@ -1,8 +1,10 @@
 import { Exclude } from 'class-transformer';
+import { Feed } from 'src/feed/entities/feed.entity';
 import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryColumn,
   UpdateDateColumn,
 } from 'typeorm';
@@ -18,7 +20,6 @@ export class Book {
   subIsbn: string;
 
   @Column()
-  @Exclude()
   title: string;
 
   @Column()
@@ -38,4 +39,7 @@ export class Book {
   @Column({ default: false })
   @Exclude()
   isDeleted: boolean;
+
+  @OneToMany(() => Feed, (feed) => feed.book)
+  feeds: Feed[];
 }

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsObject,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Book } from 'src/book/entities/book.entity';
+import { CreateBookDto } from 'src/book/dto/create-book.dto';
 
 export class CreateFeedDto {
   @IsNotEmpty()
@@ -29,41 +37,18 @@ export class CreateFeedDto {
   feeling: string;
 
   @IsNotEmpty()
-  @IsString()
+  @IsObject()
+  @ValidateNested({ each: true })
+  @Type(() => CreateBookDto)
   @ApiProperty({
-    description: '도서 고유 번호',
-    default: '1234',
+    type: Book,
+    default: {
+      isbn: '1234',
+      subIsbn: '56789',
+      title: '눈사람 자살사건',
+      author: 'NUNU',
+      image: 'image',
+    },
   })
-  isbn: string;
-
-  @IsNotEmpty()
-  @IsString()
-  @ApiProperty({
-    description: '서브 도서 고유 번호',
-    default: '56789',
-  })
-  subIsbn: string;
-
-  @IsNotEmpty()
-  @IsString()
-  @ApiProperty({
-    description: '도서 제목',
-    default: '눈사람 자살사건',
-  })
-  title: string;
-
-  @IsNotEmpty()
-  @IsString()
-  @ApiProperty({
-    description: '저자',
-    default: 'NUNU',
-  })
-  author: string;
-
-  @IsString()
-  @ApiProperty({
-    description: '썸네일 이미지 url',
-    default: 'image',
-  })
-  image: string;
+  book: Book;
 }

--- a/src/feed/entities/feed.entity.ts
+++ b/src/feed/entities/feed.entity.ts
@@ -21,12 +21,10 @@ export class Feed {
 
   @ManyToOne(() => Book, (book) => book.isbn, {
     onDelete: 'CASCADE',
+    eager: true,
   })
   @JoinColumn({ name: 'isbn' })
-  isbn: string;
-
-  @Column()
-  title: string;
+  book: Book;
 
   @ManyToOne(() => User, (user) => user.id, {
     onDelete: 'CASCADE',

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -24,20 +24,12 @@ export class FeedService {
     createFeedDto: CreateFeedDto,
   ): Promise<ApiResponse<{ id: number; createdAt: Date }>> {
     try {
-      await this.booksRepository.save(createFeedDto);
+      await this.booksRepository.save(createFeedDto.book);
 
-      const { categoryName, sentence, feeling, isbn, title } = createFeedDto;
-
-      const feed = {
-        categoryName,
-        sentence,
-        feeling,
-        isbn,
+      const { id, createdAt } = await this.feedsRepository.save({
+        ...createFeedDto,
         user,
-        title,
-      };
-
-      const { id, createdAt } = await this.feedsRepository.save(feed);
+      });
 
       return {
         message: responseMessage.CREATE_ONE_FEED_SUCCESS,
@@ -67,6 +59,7 @@ export class FeedService {
         order: { createdAt: 'DESC' },
       });
     }
+
     return {
       message: responseMessage.READ_ALL_FEEDS_SUCCESS,
       data: {
@@ -76,7 +69,7 @@ export class FeedService {
     };
   }
 
-  async findOne(feedId: string) {
+  async findOne(feedId: string): Promise<ApiResponse<{ feed: Feed }>> {
     if (!+feedId) {
       throw new HttpException(
         {
@@ -96,23 +89,10 @@ export class FeedService {
       );
     }
 
-    const book = await this.booksRepository.findOneBy({ isbn: feed.isbn });
-    if (!book || book.isDeleted) {
-      throw new HttpException(
-        {
-          message: responseMessage.NO_BOOK,
-        },
-        HttpStatus.NOT_FOUND,
-      );
-    }
-    const { author, image } = book;
-
     return {
       message: responseMessage.READ_ONE_FEED_SUCCESS,
       data: {
-        ...feed,
-        author,
-        image,
+        feed,
       },
     };
   }


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #57 

<br>




## Describe your changes 🧾


- 기존에 book과 feed 엔티티 사이 관계가 제대로 정의되어 있지 않던 문제 해결 -> 이에 따라 ```피드 등록```, ```피드 상세 조회``` 로직이 변경되었고 & 클라이언트와의 요청, 응답 포맷도 일부 수정됨.
< 참고: https://www.notion.so/20220624-Feed-book-undefined-issue-be2f3cd23a1b4fdab1eaae0919e028b7, https://www.notion.so/9454747692c84b0697ce8f9e5c62d0ce >
- feed 테이블 __title__ 컬럼이 더 이상 필요 없게 되어 삭제함.
- create-feed.dt에 Book 객체가 추가되면서 데이터 유효성 검사를 위해 __create-book.dto__ 정의함.

<br>


