### PR TITLE
[FEAT] Migration 구현 완료

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,44 @@
-# Readme-Server  
+# Readme-Server
+
 ### 우리들의 독서 기록 서비스, ReadMe
 
 ![Readme_Poster](https://hyositive.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F8fef7675-7e20-45cf-b799-261a720c9f9c%2Freadme_poster.png?table=block&id=0ff82538-4d41-4e83-9a71-9e4bb2d80272&spaceId=f98cfd80-f6e5-42e4-a0a5-36dd0972ab15&width=2000&userId=&cache=v2)
 
-
 > 타인의 마음을 울린 문장과 느낀 점을 읽고,
-기록을 통해 나를 읽는 서비스
+> 기록을 통해 나를 읽는 서비스
 
 > SOPT 30th SOPT-Term </b>
 >
 > 프로젝트 기간: 2022.03.21 ~ 2022.05.15
 
-### 🛠 Development Environment   
+### 🛠 Development Environment
+
 ![Typescript](https://img.shields.io/badge/Typescript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
 ![NodeJS](https://img.shields.io/badge/Node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)
 ![Nest](https://img.shields.io/badge/Nest-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1.svg?style=for-the-badge&logo=postgresql&logoColor=white)
 ![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)
 
-### 🧑‍💻 Developers   
-| 김은지 | 심정욱 | 김영권 | 주효식 |
-| :---: | :---: | :---: | :---: | 
-|<img src="https://avatars.githubusercontent.com/u/70746467?v=4" width="200px" height="200px" />|<img src ="https://avatars.githubusercontent.com/u/44252639?v=4" width = "200px" height="200px" />|<img src ="https://avatars.githubusercontent.com/u/39653584?v=4" width = "200px" height="200px" />|<img src ="https://avatars.githubusercontent.com/u/21357387?v=4" width = "200px" height="200px" />|
-|[eunji8784](https://github.com/eunji8784)|[junguksim](https://github.com/junguksim)|[youngkwon02](https://github.com/youngkwon02)|[HYOSITIVE](https://github.com/HYOSITIVE)| 
+### 🧑‍💻 Developers
+
+|                                             김은지                                              |                                               심정욱                                               |                                               김영권                                               |                                               주효식                                               |
+| :---------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------: |
+| <img src="https://avatars.githubusercontent.com/u/70746467?v=4" width="200px" height="200px" /> | <img src ="https://avatars.githubusercontent.com/u/44252639?v=4" width = "200px" height="200px" /> | <img src ="https://avatars.githubusercontent.com/u/39653584?v=4" width = "200px" height="200px" /> | <img src ="https://avatars.githubusercontent.com/u/21357387?v=4" width = "200px" height="200px" /> |
+|                            [eunji8784](https://github.com/eunji8784)                            |                             [junguksim](https://github.com/junguksim)                              |                           [youngkwon02](https://github.com/youngkwon02)                            |                             [HYOSITIVE](https://github.com/HYOSITIVE)                              |
+
+### How to migrate
+
+1. `npm run typeorm:migration:create -n <Migration name>` 명령어를 통해서 migration 파일을 생성한다. 이름은 `CreateFoodTable` 같이, 해당 Migration 을 통해 이루고자 하는 목적을 토대로 짓는다.
+2. 그럼 root directory 에 `1657358615321-CreateFoodTable.ts` 같이 `<타임스탬프>-<MigrationName>` 형태의 파일이 생긴다.
+3. Migration 파일의 up 함수에 `await queryRunner.메서드` 를 통해 다양한 DB 작업을 실행할 수 있다.
+   1. 예를 들어, CreateFoodTable 의 경우는
+   ```typescript
+   await queryRunner.query(`CREATE TABLE Food ~~~~`);
+   ```
+4. down 함수는 revert 가 필요할 때 실행된다. up 함수에서 했던 것을 지워주는 형태로 하면 작성하면 된다.
+   1. 예를 들어, CreateFoodTable 의 경우는
+   ```typescript
+   await queryRunner.query(`DROP TABLE Food`);
+   ```
+5. up 함수를 실행하려면, `npm run typeorm:migration:up`
+6. down 함수를 실행하려면, `npm run typeorm:migration:down`

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "rimraf": "^3.0.2",
         "rxjs": "^7.5.5",
         "swagger-ui-express": "^4.4.0",
-        "typeorm": "^0.3.6",
+        "typeorm": "^0.3.7",
         "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
@@ -51,7 +51,7 @@
         "supertest": "^6.1.3",
         "ts-jest": "^27.0.3",
         "ts-loader": "^9.2.3",
-        "ts-node": "^10.0.0",
+        "ts-node": "^10.8.2",
         "tsconfig-paths": "^3.10.1",
         "typescript": "^4.3.5"
       }
@@ -810,22 +810,13 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "devOptional": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
@@ -1266,7 +1257,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
       "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1275,13 +1266,13 @@
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
       "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
-      "dev": true,
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -8673,12 +8664,12 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
+      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
       "devOptional": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -8689,7 +8680,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
@@ -8833,9 +8824,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.6.tgz",
-      "integrity": "sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
+      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",
@@ -8868,12 +8859,12 @@
       },
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
-        "@sap/hana-client": "^2.11.14",
+        "@sap/hana-client": "^2.12.25",
         "better-sqlite3": "^7.1.2",
         "hdb-pool": "^0.1.6",
-        "ioredis": "^4.28.3",
+        "ioredis": "^5.0.4",
         "mongodb": "^3.6.0",
-        "mssql": "^6.3.1",
+        "mssql": "^7.3.0",
         "mysql2": "^2.2.5",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
@@ -8881,7 +8872,7 @@
         "pg-query-stream": "^4.0.0",
         "redis": "^3.1.1 || ^4.0.0",
         "sql.js": "^1.4.0",
-        "sqlite3": "^5.0.2",
+        "sqlite3": "^5.0.3",
         "ts-node": "^10.7.0",
         "typeorm-aurora-data-api-driver": "^2.0.0"
       },
@@ -9094,9 +9085,9 @@
       "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
@@ -10035,19 +10026,13 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "devOptional": true
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "devOptional": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@eslint/eslintrc": {
@@ -10401,19 +10386,19 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
       "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
-      "dev": true
+      "devOptional": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
       "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
-      "dev": true
+      "devOptional": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
-      "dev": true,
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -15958,12 +15943,12 @@
       }
     },
     "ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
+      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
       "devOptional": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -15974,7 +15959,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -16076,9 +16061,9 @@
       }
     },
     "typeorm": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.6.tgz",
-      "integrity": "sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
+      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
       "requires": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",
@@ -16201,9 +16186,9 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "ts-node-dev ./node_modules/typeorm/cli.js",
+    "typeorm:migration:create": "npm run build && typeorm migration:create",
+    "typeorm:migration:up": "npm run build && typeorm migration:run -d dist/database/ormconfig.js",
+    "typeorm:migration:down": "npm run build && typeorm migration:revert -d dist/database/ormconfig.js"
   },
   "dependencies": {
     "@nestjs/axios": "^0.0.8",
@@ -41,7 +45,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.5",
     "swagger-ui-express": "^4.4.0",
-    "typeorm": "^0.3.6",
+    "typeorm": "^0.3.7",
     "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
@@ -63,7 +67,7 @@
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
+    "ts-node": "^10.8.2",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"
   },

--- a/src/database/ormconfig.ts
+++ b/src/database/ormconfig.ts
@@ -1,0 +1,16 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
+export const connectionSource = new DataSource({
+  type: 'postgres',
+  host: 'readme-db.cnhsfzeymdfu.ap-northeast-2.rds.amazonaws.com',
+  port: 5432,
+  username: 'readme',
+  password: 'flemaltjqj4$',
+  database: 'postgres',
+  entities: [__dirname + '/**/*.entity.{js,ts}'],
+  namingStrategy: new SnakeNamingStrategy(),
+  synchronize: false,
+  migrationsTableName: 'migrations',
+  migrations: ['dist/migrations/*{.ts,.js}'],
+});


### PR DESCRIPTION
## Issue Ticket 🎫
- Close #65 

## Describe your changes 🧾
- 많은 우여곡절에서 알아낸 것들
1. `typeorm` 버전 `0.3.0` 이상부터는 migration 시에 dataSource 라는 속성을 정의해줘야 한다.
2. 그래서 만든게 database 폴더의 ormconfig.ts 파일
3. 저 버전 이상부터는 저렇게 만들어낸 ormconfig.ts 를 바탕으로, repository 만드는 방식 등도 모두 바뀌었는데, 그런 변화는 현재 필요없다고 생각함

- 문제점
1. config service 를 통해서 동적으로 얻어오고 있지 않음
2. https://talentwilshowitself.tistory.com/entry/NestJS-TypeORM-Migration-%EC%84%A4%EC%A0%95
3. 여기서 ormcofing.json 을 동적으로 만들고, 이를 사용하는 방법을 설명하고 있는데 아마 0.2.0 버전 대의 기준인 것 같다
4. 그래서 일단 migration 은 production, synchronize 는 dev 에서 사용하는 형태로 만들고, `ormconfig.ts` 파일의 host 나 다른 내용들은 production 기준으로 맞춰두면 될 것 같다.
5. 나중에 production 용 RDS 가 새로 생기면 다 바꾸면 될듯


