### PR TITLE
[FIX] 소셜 로그인 성공 시 user 객체 반환

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -86,7 +86,7 @@ export class UserService {
   async socialLogin(loginUserDto: LoginUserDto): Promise<
     ApiResponse<{
       isNewUser: boolean;
-      nickname?: string;
+      user?: User;
       accessToken?: string;
     }>
   > {
@@ -123,7 +123,7 @@ export class UserService {
       message: responseMessage.SOCIAL_LOGIN_SUCCESS,
       data: {
         isNewUser: false,
-        nickname: user.nickname,
+        user: user,
         accessToken,
       },
     };


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #69 

<br>




## Describe your changes 🧾

- 기존에 클라 요청으로 nickname 추가했었음
- 추가로 userId도 요청 -> user 객체 안에 userId, nickname 모두 있으므로 user 객체 반환

- response result
```json
{
  "status": 200,
  "success": true,
  "message": "소셜 로그인 성공",
  "data": {
    "isNewUser": false,
    "user": {
      "id": 17,
      "nickname": "이창환"
    },
    "accessToken": "accessToken"
  }
}
```


<br>


