### PR TITLE
[FIX] 도서 ISBN 없는 경우 예외 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lerna-debug.log*
 
 # configs
 .env
+
+# vscode settings
+.vscode

--- a/src/book/dto/create-book.dto.ts
+++ b/src/book/dto/create-book.dto.ts
@@ -1,11 +1,9 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateBookDto {
-  @IsNotEmpty()
   @IsString()
   isbn: string;
 
-  @IsNotEmpty()
   @IsString()
   subIsbn: string;
 
@@ -13,11 +11,9 @@ export class CreateBookDto {
   @IsString()
   title: string;
 
-  @IsNotEmpty()
   @IsString()
   author: string;
 
-  @IsNotEmpty()
   @IsString()
   image: string;
 }

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -38,6 +38,7 @@ export class CreateFeedDto {
 
   @IsNotEmpty()
   @IsObject()
+  @ValidateNested({ each: true })
   @Type(() => CreateBookDto)
   @ApiProperty({
     type: Book,

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -38,7 +38,6 @@ export class CreateFeedDto {
 
   @IsNotEmpty()
   @IsObject()
-  @ValidateNested({ each: true })
   @Type(() => CreateBookDto)
   @ApiProperty({
     type: Book,

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -25,10 +25,29 @@ export class FeedService {
   ): Promise<ApiResponse<{ id: number; createdAt: Date }>> {
     try {
       if (!createFeedDto.book.isbn) {
-        const fakeISBN = Math.floor(Math.random() * 10000000000).toString() + 'F';
-        createFeedDto.book.isbn = fakeISBN;
+        // 해당 도서의 ISBN이 존재하지 않는 경우
+        const fakeISBN =
+          Math.floor(Math.random() * 10000000000).toString() + 'F';
+        if (!createFeedDto.book.author) {
+          // 해당 도서의 저자 정보도 존재하지 않는 경우 : 중복 확인 불가. 새로운 책 생성
+          createFeedDto.book.isbn = fakeISBN;
+          await this.booksRepository.save(createFeedDto.book);
+        } else {
+          // 해당 도서의 저자 정보는 존재하는 경우 : 제목, 저자로 중복 확인
+          const existingBook = await this.booksRepository.findOneBy({
+            title: createFeedDto.book.title,
+            author: createFeedDto.book.author,
+          });
+          if (existingBook) {
+            // 기존 등록된 책 존재 : 기존 등록된 책을 createFeedDto에 할당
+            createFeedDto.book = existingBook;
+          } else {
+            // 책 신규 등록 : 랜덤 fakeISBN을 활용해 book Repository에 새로운 책 생성
+            createFeedDto.book.isbn = fakeISBN;
+            await this.booksRepository.save(createFeedDto.book);
+          }
+        }
       }
-      await this.booksRepository.save(createFeedDto.book);
 
       const { id, createdAt } = await this.feedsRepository.save({
         ...createFeedDto,

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -24,6 +24,10 @@ export class FeedService {
     createFeedDto: CreateFeedDto,
   ): Promise<ApiResponse<{ id: number; createdAt: Date }>> {
     try {
+      if (!createFeedDto.book.isbn) {
+        const fakeISBN = Math.floor(Math.random() * 10000000000).toString() + 'F';
+        createFeedDto.book.isbn = fakeISBN;
+      }
       await this.booksRepository.save(createFeedDto.book);
 
       const { id, createdAt } = await this.feedsRepository.save({


### PR DESCRIPTION
close #68 

## Issue Ticket 🎫

- 도서에 ISBN, 저자, 이미지 등이 없는 경우가 존재함
- DB의 book table에서 ISBN을 id로 사용하고 있어 ISBN이 없을 경우 문제 발생 가능

<br>




## Describe your changes 🧾

- ISBN이 빈 경우, 랜덤 숫자를 생성해 가짜 ISBN으로 사용 (식별을 위해 숫자 뒤에 'F' 사용)
- ISBN, 저자, 이미지 등이 없는 경우에도 book 객체는 생성되어야 하므로, create-feed DTO에서 ValidateNested 옵션 삭제

<br>


