### PR TITLE
[FIX] 탈퇴한 회원의 닉네임과 신규 회원의 닉네임이 중복될 수 있도록 처리

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -19,7 +19,10 @@ export class AuthService {
   async createAccessToken(
     nickname: string,
   ): Promise<ApiResponse<{ accessToken: string }>> {
-    const user = await this.usersRepository.findOneBy({ nickname });
+    const user = await this.usersRepository.findOneBy({
+      nickname,
+      isDeleted: false,
+    });
 
     if (user) {
       const payload = {

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -18,7 +18,7 @@ export class User {
   @Exclude()
   uid: string;
 
-  @Column({ unique: true })
+  @Column()
   nickname: string;
 
   @Column({ nullable: true })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -56,7 +56,10 @@ export class UserService {
       uid = await this.getNaverUid(socialToken);
     }
 
-    const existingUser = await this.usersRepository.findOneBy({ nickname });
+    const existingUser = await this.usersRepository.findOneBy({
+      nickname,
+      isDeleted: false,
+    });
     if (existingUser) {
       throw new HttpException(
         { message: responseMessage.DUPLICATE_NICKNAME },
@@ -97,7 +100,10 @@ export class UserService {
       uid = await this.getNaverUid(socialToken);
     }
 
-    const user = await this.usersRepository.findOneBy({ uid });
+    const user = await this.usersRepository.findOneBy({
+      uid,
+      isDeleted: false,
+    });
     // new signing up user
     if (!user) {
       return {


### PR DESCRIPTION
## Issue Ticket 🎫

- closed #74 

<br>




## Describe your changes 🧾


- user.entity - nickname 컬럼 unique 옵션 삭제
- 회원가입, 로그인, 어세스토큰 발급 시 user 정보 가져올 때 isDeleted false 조건 추가

<br>


