### PR TITLE
[FIX] Fix findRecentBook deduplicate logic

### DIFF
--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -163,12 +163,19 @@ export class FeedService {
       where: { isDeleted: false, user: theUser },
       order: { createdAt: 'DESC' },
     });
+
     const duplicatedBooks = myFeeds.map((row) => row.book);
-    const books = [...new Set(duplicatedBooks)];
+    const resultBooks = duplicatedBooks.filter(
+      (book, index) =>
+        duplicatedBooks.findIndex(
+          (firstBook) => firstBook.isbn === book.isbn,
+        ) === index,
+    );
+
     return {
       message: responseMessage.READ_RECENT_BOOKS_SUCCESS,
       data: {
-        books: books,
+        books: resultBooks,
       },
     };
   }


### PR DESCRIPTION
## Issue Ticket 🎫

- close #76 

<br>




## Describe your changes 🧾


- 기존 spread syntax와 new Set을 이용한 방식으로는 클래스 인스턴스들의 배열에서 중복이 제거되지 않아, filter와 findIndex를 활용한 방법으로 변경

<br>


